### PR TITLE
bump the version of omniauth-google-oauth2 used

### DIFF
--- a/spree_social.gemspec
+++ b/spree_social.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'omniauth-twitter'
   s.add_runtime_dependency 'omniauth-facebook'
   s.add_runtime_dependency 'omniauth-github'
-  s.add_runtime_dependency 'omniauth-google-oauth2', '<= 0.6.0'
+  s.add_runtime_dependency 'omniauth-google-oauth2', '>= 0.6.0'
   s.add_runtime_dependency 'omniauth-amazon'
 
   s.add_development_dependency 'capybara', '~> 2.18.0'

--- a/spree_social.gemspec
+++ b/spree_social.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'omniauth-twitter'
   s.add_runtime_dependency 'omniauth-facebook'
   s.add_runtime_dependency 'omniauth-github'
-  s.add_runtime_dependency 'omniauth-google-oauth2', '0.4.1'
+  s.add_runtime_dependency 'omniauth-google-oauth2', '<= 0.6.0'
   s.add_runtime_dependency 'omniauth-amazon'
 
   s.add_development_dependency 'capybara', '~> 2.18.0'


### PR DESCRIPTION
Google is deprecating sign ins with Google+
in order to prevent logins via Google from breaking, we need to bump the version of omniauth-google-oauth2 used which fortunately is compliant as of v 0.6.0
https://github.com/zquestz/omniauth-google-oauth2/blob/master/CHANGELOG.md#060---2018-12-28